### PR TITLE
Fix pagination, clean option, allow fetching collection episodes.

### DIFF
--- a/export_trakt.py
+++ b/export_trakt.py
@@ -34,6 +34,7 @@ import configparser
 import datetime
 import collections
 import pprint
+import time
 
 import helpers
 
@@ -84,6 +85,9 @@ response_arr = []
 def write_csv(options, results):
     """Write list output into a CSV file format
         """
+    if len(results) == 0:
+        return None
+
     print("Writing to: {0}".format(options.output))
     # Write result CSV, works with windows now
     with open(options.output, 'w', encoding='utf-8', newline='') as fp:
@@ -100,10 +104,9 @@ def write_csv(options, results):
 def api_remove_from_list(options, remove_data, is_id=False):
     """API call for Sync / Remove from list
         """
+    time.sleep(1)
     url = _trakt['baseurl'] + '/sync/{list}/remove'.format(list=options.list)
-    if options.type == 'episodes':
-        values = {'shows': remove_data}
-    elif not is_id:
+    if not is_id:
         values = {options.type: remove_data}
     else:
         values = {'ids': remove_data}
@@ -199,10 +202,10 @@ def process_export_data(options, export_data):
                 result = api_remove_from_list(options, to_remove)
                 if result:
                     print("Result: {0}".format(result))
-                    if 'deleted' in result and result['deleted']:
+                    if 'deleted' in result and result['deleted'] and options.type != "shows":
                         cleanup_results['deleted'] += result['deleted'][
                             options.type]
-                    if 'not_found' in result and result['not_found']:
+                    if 'not_found' in result and result['not_found'] and options.type != "shows":
                         cleanup_results['not_found'] += len(
                             result['not_found'][options.type])
                 to_remove = []
@@ -213,10 +216,10 @@ def process_export_data(options, export_data):
             result = api_remove_from_list(options, to_remove)
             if result:
                 print("Result: {0}".format(result))
-                if 'deleted' in result and result['deleted']:
+                if 'deleted' in result and result['deleted'] and options.type != "shows":
                     cleanup_results['deleted'] += result['deleted'][
                         options.type]
-                if 'not_found' in result and result['not_found']:
+                if 'not_found' in result and result['not_found'] and options.type != "shows":
                     cleanup_results['not_found'] += len(
                         result['not_found'][options.type])
         print(

--- a/export_trakt.py
+++ b/export_trakt.py
@@ -170,16 +170,21 @@ def process_export_data(options, export_data):
             if not data['episode']['title']:
                 data['episode']['title'] = "no episode title"
 
-            export_csv.append({
+            row = {
                 options.time: data[options.time],
                 'season': data[options.type[:-1]]['season'],
                 'episode': data[options.type[:-1]]['number'],
                 'episode_title': data['episode']['title'],
-                'show_title': data['show']['title'],
+                'show_title': '',
                 'trakt': data[options.type[:-1]]['ids']['trakt'],
                 'tvdb': data[options.type[:-1]]['ids']['tvdb'],
                 'tmdb': data[options.type[:-1]]['ids']['tmdb']
-            })
+            }
+            if options.list == "collection":
+                del row['show_title']
+            else:
+                row['show_title'] = data['show']['title']
+            export_csv.append(row)
     # TODO: Don't know if options.clean works
     ## Empty list after export
     if options.clean:
@@ -358,12 +363,6 @@ def main():
     ## Display debug information
     if options.verbose:
         print("Options: %s" % options)
-
-    if options.type == 'episodes' and options.list == "collection":
-        print(
-            "Error, you can only fetch {0} from the history or watchlist list".
-            format(options.type))
-        sys.exit(1)
 
     if options.userlist:
         options.list = "user list"

--- a/helpers.py
+++ b/helpers.py
@@ -270,13 +270,13 @@ def api_get_request(_headers, _proxyDict, options, url, page):
     if options.verbose:
         print(url)
     if _proxy['proxy']:
-        r = requests.get(url,
+        r = requests.get(url + "&page={0}".format(page),
                          headers=_headers,
                          proxies=_proxyDict,
                          timeout=(10, 60))
     else:
-        r = requests.get(url, headers=_headers, timeout=(5, 60))
-    #pp.pprint(r.headers)
+        r = requests.get(url + "&page={0}".format(page), headers=_headers, timeout=(5, 60))
+
     if r.status_code != 200:
         print(
             "Error fetching GET response for {list}: {status} [{text}]".format(
@@ -285,10 +285,9 @@ def api_get_request(_headers, _proxyDict, options, url, page):
     else:
         json_dict = json.loads(r.text)
         if type(json_dict) is list:
-            response_arr += json.loads(r.text)
+            response_arr += json_dict
         else:
             response_arr.append(json_dict)
-    #print(response_arr)
 
     # if 'X-Pagination-Page-Count'in r.headers and r.headers['X-Pagination-Page-Count'] != "0":
     if 'X-Pagination-Page-Count' in r.headers and r.headers[
@@ -302,7 +301,7 @@ def api_get_request(_headers, _proxyDict, options, url, page):
             PageCount=r.headers['X-Pagination-Page-Count'],
             list=options.list))
         if page != int(r.headers['X-Pagination-Page-Count']):
-            api_get_request(_headers, _proxyDict, options, url, page + 1)
+            response_arr += api_get_request(_headers, _proxyDict, options, url, page + 1)
 
     return response_arr
 
@@ -311,7 +310,7 @@ def api_get_list(_trakt, _headers, _proxyDict, options, page):
     """Get items of default list (e.g history) by type starting from page
         """
     url = _trakt[
-        'baseurl'] + '/sync/{list}/{type}?page={page}&limit={limit}'.format(
+        'baseurl'] + '/sync/{list}/{type}?limit={limit}'.format(
             list=options.list, type=options.type, page=page, limit=1000)
     return api_get_request(_headers, _proxyDict, options, url, page)
 
@@ -319,18 +318,15 @@ def api_get_list(_trakt, _headers, _proxyDict, options, page):
 def api_get_userlists(_trakt, _headers, _proxyDict, options, page):
     """Get list of all user lists
         """
-    url = _trakt['baseurl'] + '/users/{user}/lists'.format(
+    url = _trakt['baseurl'] + '/users/{user}/lists?limit={limit}'.format(
         user=_trakt['username'], page=page, limit=1000)
-    #url = _trakt['baseurl'] + '/users/{user}/lists/{list_id}?page={page}&limit={limit}'.format(
-    #                    list=options.list, type=options.type, page=page, limit=1000)
-    # print(url)
     return api_get_request(_headers, _proxyDict, options, url, page)
 
 
 def api_get_userlist(_trakt, _headers, _proxyDict, options, page):
     """Get items of user list by type
         """
-    url = _trakt['baseurl'] + '/users/{user}/lists/{list_id}'.format(
+    url = _trakt['baseurl'] + '/users/{user}/lists/{list_id}?limit={limit}'.format(
         user=_trakt['username'],
         list_id=options.listid,
         type=options.type,
@@ -343,7 +339,7 @@ def api_get_userlist_items(_trakt, _headers, _proxyDict, options, page):
     """Get items of user list by type
         """
     url = _trakt[
-        'baseurl'] + '/users/{user}/lists/{list_id}/items/{type}?page={page}&limit={limit}'.format(
+        'baseurl'] + '/users/{user}/lists/{list_id}/items/{type}&limit={limit}'.format(
             user=_trakt['username'],
             list_id=options.listid,
             type=options.type,


### PR DESCRIPTION
Your fork worked better for me than the original. I fixed some bugs and added a feature I needed while exporting my data.

- Fix request pagination. Refactoring to helpers.py caused request pagination to break so only the first 1000 items would be fetched.
- Allow fetching episodes from collection. Even in the original it was disabled because the api does not provide the show title which is used to build the csv. But it is not needed for import/export to work.
- Fix clean option not deleting. Fixed by adding a delay and disabling some of the output messages, which don't display useful information regardless (these cleanup messages need to be fixed or removed completely).